### PR TITLE
fix scripts and typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Check out, build and install `dump1090`:
 cd ~/raspberry-pi-adsb
 ./setup-dump1090.sh
 ```
-The `setup-dump1090.sh` also installs `dump1090` was as a service so that `dump1090` starts automatically after system restart.
+The `setup-dump1090.sh` also installs `dump1090` as a service so that `dump1090` starts automatically after system restart.
 
 You will be once again prompted to reboot after the set up. 
 

--- a/setup-dump1090.sh
+++ b/setup-dump1090.sh
@@ -4,7 +4,7 @@ cd ~
 git clone git://github.com/MalcolmRobb/dump1090.git
 cd dump1090
 make
-cd ~/adsb-base-station
+cd ~/raspberry-pi-adsb
 sudo cp dump1090.sh /etc/init.d/
 sudo chmod +x /etc/init.d/dump1090.sh
 sudo update-rc.d dump1090.sh defaults

--- a/setup-rtl-sdr.sh
+++ b/setup-rtl-sdr.sh
@@ -9,8 +9,8 @@ cmake ../ -DINSTALL_UDEV_RULES=ON
 make
 sudo make install
 sudo ldconfig
-sudo cp rtl-sdr.rules /etc/udev/rules.d/
-cd ~/adsb-base-station
+sudo cp ~/rtl-sdr/rtl-sdr.rules /etc/udev/rules.d/
+cd ~/raspberry-pi-adsb
 sudo cp nortl.conf /etc/modprobe.d/
 DEFAULT="y"
 read -e -p "OK to reboot the system [Y/n]?" PROCEED


### PR DESCRIPTION
Looks like repo has been renamed, but scripts were not changed. Fixed it.