### PR TITLE
Don't use unauthenticated git port

### DIFF
--- a/setup-dump1090.sh
+++ b/setup-dump1090.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 sudo apt-get install pkg-config
 cd ~
-git clone git://github.com/MalcolmRobb/dump1090.git
+git clone https://github.com/MalcolmRobb/dump1090.git
 cd dump1090
 make
 cd ~/raspberry-pi-adsb


### PR DESCRIPTION
I'm getting this error when running `setup-dump1090.sh`

>0 upgraded, 0 newly installed, 0 to remove and 302 not upgraded.
Cloning into 'dump1090'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
./setup-dump1090.sh: line 5: cd: dump1090: No such file or directory
make: *** No targets specified and no makefile found.  Stop.

This is because it's using the `git://` protocol to clone the repo, which is no longer supported when unauthenticated.